### PR TITLE
Bump s3fs minimum version to 2022.02.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages = find:
 include_package_data = True
 install_requires =
     dvc
-    s3fs>=2021.11.0
+    s3fs>=2022.02.0
     aiobotocore[boto3]>1.0.1
     flatten_dict>=0.4.1,<1
 


### PR DESCRIPTION
dvc pull fails on s3fs versions prior 2022.02.0 with

```
TypeError: _get_file() got an unexpected keyword argument 'callback'
```

This was fixed before this plugin was extracted in https://github.com/iterative/dvc/pull/7672