### PR TITLE
tests: use real S3 when DVC_TEST_AWS_REPO_BUCKET is set

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,10 @@
 dvc-s3
+======
 
 s3 plugin for dvc
+
+Tests
+-----
+
+By default tests will be run against moto (via pytest-servers).
+To run against real S3, set ``DVC_TEST_AWS_REPO_BUCKET`` with an AWS bucket name.

--- a/dvc_s3/tests/benchmarks.py
+++ b/dvc_s3/tests/benchmarks.py
@@ -1,1 +1,3 @@
-from dvc.testing.benchmarks.cli.stories.use_cases.test_sharing import *  # noqa, pylint: disable=wildcard-import,unused-import
+from dvc.testing.benchmarks.cli.stories.use_cases.test_sharing import (  # noqa, pylint: disable=unused-import
+    test_sharing as test_sharing_s3,
+)

--- a/dvc_s3/tests/cloud.py
+++ b/dvc_s3/tests/cloud.py
@@ -6,8 +6,6 @@ from dvc.testing.cloud import Cloud
 from dvc.testing.path_info import CloudURLInfo
 from funcy import cached_property
 
-TEST_AWS_REPO_BUCKET = os.environ.get("DVC_TEST_AWS_REPO_BUCKET", "dvc-temp")
-
 
 class S3(Cloud, CloudURLInfo):
     @property
@@ -16,13 +14,9 @@ class S3(Cloud, CloudURLInfo):
 
     @staticmethod
     def _get_storagepath():
-        return (
-            TEST_AWS_REPO_BUCKET
-            + "/"
-            + "dvc_test_caches"
-            + "/"
-            + str(uuid.uuid4())
-        )
+        bucket = os.environ.get("DVC_TEST_AWS_REPO_BUCKET")
+        assert bucket
+        return bucket + "/" + "dvc_test_caches" + "/" + str(uuid.uuid4())
 
     @staticmethod
     def get_url():

--- a/dvc_s3/tests/fixtures.py
+++ b/dvc_s3/tests/fixtures.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from .cloud import S3, FakeS3
@@ -5,8 +7,12 @@ from .cloud import S3, FakeS3
 
 @pytest.fixture
 # pylint: disable-next=redefined-outer-name,unused-argument
-def make_s3(tmp_s3_path, s3_server, request):
+def make_s3(request):
     def _make_s3():
+        if os.environ.get("DVC_TEST_AWS_REPO_BUCKET"):
+            return S3(S3.get_url())
+        tmp_s3_path = request.getfixturevalue("tmp_s3_path")
+        s3_server = request.getfixturevalue("s3_server")
         return FakeS3(str(tmp_s3_path).rstrip("/"), endpoint_url=s3_server)
 
     return _make_s3
@@ -24,11 +30,6 @@ def make_s3_version_aware(versioning, tmp_s3_path, s3_server):
 @pytest.fixture
 def s3(make_s3):  # pylint: disable=redefined-outer-name
     yield make_s3()
-
-
-@pytest.fixture
-def real_s3():
-    yield S3(S3.get_url())
 
 
 @pytest.fixture


### PR DESCRIPTION
previous configuration was to use a separate `real_s3` fixture, but what we really want is for the standard remote/cloud/s3 fixture workflow to decide whether to use moto or real S3 based on the environment (so we don't have to define separate tests for real vs fake s3) 