### PR TITLE
benchmarks: remove test_modify_data from benchmarks

### DIFF
--- a/dvc_s3/tests/benchmarks.py
+++ b/dvc_s3/tests/benchmarks.py
@@ -1,11 +1,5 @@
 # pylint: disable=unused-import
 # noqa
-from dvc.testing.benchmarks.cli.stories.test_modify_data import (  # noqa
-    test_partial_add as test_partial_add_s3,
-)
-from dvc.testing.benchmarks.cli.stories.test_modify_data import (  # noqa
-    test_partial_remove as test_partial_remove_s3,
-)
 from dvc.testing.benchmarks.cli.stories.use_cases.test_sharing import (  # noqa
     test_sharing as test_sharing_s3,
 )


### PR DESCRIPTION
The partial add/remove benchmarks are not useful for real clouds and just negatively affect the overall CI runtime, see: https://github.com/iterative/dvc/issues/9108#issuecomment-1541421352