### PR TITLE
deps: bump minver of s3fs to 2023.6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = True
 install_requires =
     dvc
     s3fs>=2023.4.0
-    aiobotocore[boto3]>1.0.1
+    aiobotocore[boto3]>=2.5.0
     flatten_dict>=0.4.1,<1
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 include_package_data = True
 install_requires =
     dvc
-    s3fs>=2022.02.0
+    s3fs>=2023.4.0
     aiobotocore[boto3]>1.0.1
     flatten_dict>=0.4.1,<1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 include_package_data = True
 install_requires =
     dvc
-    s3fs>=2023.4.0
+    s3fs>=2023.6.0
     aiobotocore[boto3]>=2.5.0
     flatten_dict>=0.4.1,<1
 


### PR DESCRIPTION
So that we require aiobotocore>=2.5.0.