### PR TITLE
deps: don't install pytest-docker

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ tests =
     pytest-xdist==2.4.0
     pytest-mock==3.6.1
     pytest-lazy-fixture==0.6.3
-    pytest-docker==0.10.3
     pytest-servers[s3]==0.2.0
     flaky==3.7.0
     mock==4.0.3


### PR DESCRIPTION
Doesn't seem like we are using it these days after pytest-servers migration.