### PR TITLE
ensure that s3 is connected before using the s3fs api

### DIFF
--- a/dvc_s3/__init__.py
+++ b/dvc_s3/__init__.py
@@ -240,7 +240,10 @@ class S3FileSystem(ObjectFileSystem):
     def fs(self):
         from s3fs import S3FileSystem as _S3FileSystem
 
-        return _S3FileSystem(**self.fs_args)
+        s3_filesystem =  _S3FileSystem(**self.fs_args)
+        s3_filesystem.connect()
+
+        return s3_filesystem
 
     @classmethod
     def _strip_protocol(cls, path: str) -> str:

--- a/dvc_s3/__init__.py
+++ b/dvc_s3/__init__.py
@@ -240,7 +240,7 @@ class S3FileSystem(ObjectFileSystem):
     def fs(self):
         from s3fs import S3FileSystem as _S3FileSystem
 
-        s3_filesystem =  _S3FileSystem(**self.fs_args)
+        s3_filesystem = _S3FileSystem(**self.fs_args)
         s3_filesystem.connect()
 
         return s3_filesystem


### PR DESCRIPTION
This PR aims to fix the following issue:

Using dvc with aws-vault, assume role and a source_profile occasionally fails with:

```
ERROR: unexpected error - Infinite loop in credential configuration detected. Attempting to load from profile my-profile-2 which has already been visited. Visited profiles: ['profile-1', 'profile-2']
```

Using process authentification, assume role and source_profile in the aws config, loading the credentials will fail with `InfiniteLoopConfigError` as seen in the following example:

```py
import botocore.session
import botocore.credentials

session = botocore.session.Session(profile="profile")
resolver = botocore.credentials.create_credential_resolver(session, region_name=None)

credentials = resolver.load_credentials() # <--- works
credentials = resolver.load_credentials() # <--- fails with infinite loop credentials
```

This is due to the resolver instance not setting its seen profiles state when calling the function `load_credentials`, thus when running a second time, the profile will already be present in its seen profiles raising the previously stated error.

`s3fs` will load the credentials multiple times if the session is not created before using the api with multiple threads of multiple async jobs.

Enforcing the connection when creating the S3FileSystem instance avoids this issue as stated in the s3fs [documentation](https://s3fs.readthedocs.io/en/latest/index.html#async):

> You must also explicitly await the client creation before making any S3 call.


Closes https://github.com/iterative/dvc/issues/10146.