### PR TITLE
reduce number of revs and remove scheduled jobs

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  schedule:
-    - cron: '5 1 * * *'  # every day at 01:05
   workflow_dispatch:
     inputs:
       dataset:
@@ -63,7 +61,7 @@ jobs:
 
     - name: run benchmarks
       timeout-minutes: 180
-      run: pytest --dist no --benchmark-save benchmarks-s3 --benchmark-group-by func --dvc-revs main,2.45.0,2.41.1,2.40.0,2.39.0,2.18.1,2.11.0 --dataset ${DATASET} dvc_s3/tests/benchmarks.py --dvc-install-deps s3
+      run: pytest --dist no --benchmark-save benchmarks-s3 --benchmark-group-by func --dvc-revs main,3.10.0,2.58.2 --dataset ${DATASET} dvc_s3/tests/benchmarks.py --dvc-install-deps s3
 
     - name: upload raw results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Scheduled jobs run in dvc-bench, so we don't need to rerun here.