### PR TITLE
Allow enabling anonymous login

### DIFF
--- a/dvc_s3/__init__.py
+++ b/dvc_s3/__init__.py
@@ -167,7 +167,7 @@ class S3FileSystem(ObjectFileSystem):
         # session configuration
         login_info["profile"] = config.get("profile")
         login_info["use_ssl"] = config.get("use_ssl", True)
-        login_info["anon"] = config.get("anon")
+        login_info["anon"] = config.get("allow_anonymous_login")
 
         # extra client configuration
         client = login_info["client_kwargs"]

--- a/dvc_s3/__init__.py
+++ b/dvc_s3/__init__.py
@@ -167,6 +167,7 @@ class S3FileSystem(ObjectFileSystem):
         # session configuration
         login_info["profile"] = config.get("profile")
         login_info["use_ssl"] = config.get("use_ssl", True)
+        login_info["anon"] = config.get("anon")
 
         # extra client configuration
         client = login_info["client_kwargs"]


### PR DESCRIPTION
This commit would allow to enable anonymous login for the [S3FileSystem](https://github.com/fsspec/s3fs/blob/3966b39c5d57ba14fc8fb543c1d80f66648a4096/s3fs/core.py#L278).

FYI: I saw that dvc already has an option  [allow_anonymous_login](https://github.com/iterative/dvc/blob/cbaeff2ea1a8c2d531170bf7d1ef8d31db9026db/dvc/config_schema.py#L257) for azure. Should the name be aligned? A pull request to add this option to dvc/config_schema.py would then be set up accordingly.

