### PR TITLE
feat: set user_agent_extra for S3 server-side request attribution

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,20 @@ dvc-s3
 
 s3 plugin for dvc
 
+Configuration
+-------------
+
+``dvc-s3`` appends a ``dvc-s3/<version>`` token to the S3 ``User-Agent`` so its
+traffic is identifiable on S3 server-side request logs. When the package
+metadata is unavailable (source / frozen installs) the token falls back to
+``dvc-s3/dev``.
+
+Code constructing the filesystem directly may pass ``user_agent_extra`` to
+append one or more additional product tokens (for example,
+``downstream/1.2.3``; space-separated tokens are valid ``User-Agent`` syntax).
+The value must be a string, ASCII-only, free of control characters, and is
+whitespace-trimmed; invalid values raise ``ConfigError``.
+
 Tests
 -----
 

--- a/dvc_s3/__init__.py
+++ b/dvc_s3/__init__.py
@@ -1,6 +1,8 @@
 import os
 import threading
 from collections import defaultdict
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any, ClassVar, Optional
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 
@@ -11,6 +13,35 @@ from dvc_objects.fs.base import ObjectFileSystem
 from dvc_objects.fs.errors import ConfigError
 
 _AWS_CONFIG_PATH = os.path.join(os.path.expanduser("~"), ".aws", "config")
+
+
+_DIST_NAME = "dvc-s3"
+
+
+@lru_cache(maxsize=1)
+def _user_agent_extra() -> str:
+    try:
+        return f"{_DIST_NAME}/{version(_DIST_NAME)}"
+    except PackageNotFoundError:
+        return f"{_DIST_NAME}/dev"
+
+
+def _clean_user_agent_extra(value: Optional[str]) -> str:
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ConfigError(
+            f"`user_agent_extra` must be a string, got {type(value).__name__}"
+        )
+    value = value.strip()
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in value):
+        raise ConfigError(
+            "`user_agent_extra` must not contain control characters "
+            f"(e.g. CR/LF): {value!r}"
+        )
+    if not value.isascii():
+        raise ConfigError(f"`user_agent_extra` must be ASCII-encodable: {value!r}")
+    return value
 
 
 # https://github.com/aws/aws-cli/blob/5aa599949f60b6af554fd5714d7161aa272716f7/awscli/customizations/s3/utils.py
@@ -173,6 +204,13 @@ class S3FileSystem(ObjectFileSystem):
         config_kwargs["read_timeout"] = config.get("read_timeout")
         config_kwargs["connect_timeout"] = config.get("connect_timeout")
 
+        # user agent configuration
+        default_ua = _user_agent_extra()
+        user_extra = _clean_user_agent_extra(config.get("user_agent_extra"))
+        config_kwargs["user_agent_extra"] = (
+            f"{default_ua} {user_extra}" if user_extra else default_ua
+        )
+
         # encryptions
         additional = login_info["s3_additional_kwargs"]
         sse_customer_key = None
@@ -204,8 +242,7 @@ class S3FileSystem(ObjectFileSystem):
                 additional[grant_key] = config[grant_option]
 
         # config kwargs
-        session_config = login_info["config_kwargs"]
-        session_config["s3"] = self._load_aws_config_file(login_info["profile"])
+        config_kwargs["s3"] = self._load_aws_config_file(login_info["profile"])
 
         shared_creds = config.get("credentialpath")
         if shared_creds:
@@ -213,7 +250,7 @@ class S3FileSystem(ObjectFileSystem):
 
         if (
             client["region_name"] is None
-            and session_config["s3"].get("region_name") is None
+            and config_kwargs["s3"].get("region_name") is None
             and os.getenv("AWS_REGION") is None
         ):
             # Enable bucket region caching

--- a/dvc_s3/tests/test_s3.py
+++ b/dvc_s3/tests/test_s3.py
@@ -136,3 +136,89 @@ def test_key_id_and_secret():
     assert fs.fs_args["key"] == key_id
     assert fs.fs_args["secret"] == key_secret
     assert fs.fs_args["token"] == session_token
+
+
+def test_default_user_agent_extra():
+    fs = S3FileSystem(url=url)
+    ua = fs.fs_args["config_kwargs"]["user_agent_extra"]
+    # "dvc-s3/<version>" in normal installs; "dvc-s3/dev" when package
+    # metadata is missing (source-only / frozen-binary cases).
+    assert ua.startswith("dvc-s3/")
+    assert " " not in ua  # no extra token appended by default
+
+
+def test_user_agent_extra_appends_user_value():
+    fs = S3FileSystem(url=url, user_agent_extra="downstream/1.2.3")
+    ua = fs.fs_args["config_kwargs"]["user_agent_extra"]
+    assert ua.startswith("dvc-s3/")
+    assert ua.endswith(" downstream/1.2.3")
+
+
+def test_user_agent_extra_strips_whitespace():
+    fs = S3FileSystem(url=url, user_agent_extra="  downstream/1.2.3  ")
+    ua = fs.fs_args["config_kwargs"]["user_agent_extra"]
+    assert ua.endswith(" downstream/1.2.3")
+    assert "  " not in ua
+
+
+def test_user_agent_extra_rejects_control_chars():
+    with pytest.raises(ConfigError):
+        _ = S3FileSystem(
+            url=url, user_agent_extra="downstream/1.2.3\r\nX-Evil: 1"
+        ).fs_args
+
+
+def test_user_agent_extra_rejects_non_string():
+    with pytest.raises(ConfigError):
+        _ = S3FileSystem(url=url, user_agent_extra=123).fs_args
+
+
+def test_user_agent_extra_rejects_non_ascii():
+    with pytest.raises(ConfigError):
+        _ = S3FileSystem(url=url, user_agent_extra="downstream/1.2.3 🚀").fs_args
+
+
+def test_user_agent_extra_on_the_wire(s3_config, s3_bucket):
+    fs = S3FileSystem(
+        url=f"s3://{s3_bucket}",
+        endpointurl=s3_config["endpoint_url"],
+        access_key_id=s3_config["aws_access_key_id"],
+        secret_access_key=s3_config["aws_secret_access_key"],
+        user_agent_extra="downstream/1.2.3",
+    )
+    fs.fs.ls(s3_bucket)  # warm up so the client/session is created
+
+    captured = []
+
+    def _capture(request, **_):
+        captured.append(request.headers.get("User-Agent"))
+
+    events = fs.fs.s3.meta.events
+    events.register_first("before-send.s3", _capture)
+    try:
+        fs.fs.ls(s3_bucket, refresh=True)  # force a real request (bypass dircache)
+    finally:
+        events.unregister("before-send.s3", _capture)
+
+    assert captured, "no request reached the wire"
+    ua = captured[0]
+    ua = ua.decode() if isinstance(ua, bytes) else ua
+    assert ua, "request had no User-Agent header"
+    assert "dvc-s3/" in ua
+    assert "downstream/1.2.3" in ua
+
+
+def test_user_agent_extra_dev_fallback(monkeypatch):
+    from importlib.metadata import PackageNotFoundError
+
+    import dvc_s3
+
+    def _raise(name):
+        raise PackageNotFoundError(name)
+
+    monkeypatch.setattr(dvc_s3, "version", _raise)
+    dvc_s3._user_agent_extra.cache_clear()
+    try:
+        assert dvc_s3._user_agent_extra() == "dvc-s3/dev"
+    finally:
+        dvc_s3._user_agent_extra.cache_clear()


### PR DESCRIPTION
DVC traffic on S3 server-side logs is currently indistinguishable from any other `aiobotocore` caller: `Config.user_agent_extra` is unset, so the wire UA only contains `aiobotocore/X botocore/Y`.

This sets `user_agent_extra = "dvc-s3/<version>"` on the boto3 `Config` built in `S3FileSystem._prepare_credentials`. The version is resolved lazily on first use (cached) via `importlib.metadata.version("dvc-s3")`, falling back to `"dvc-s3/dev"` for source / frozen installs (RFC 9110 product/version form preserved).

A `user_agent_extra` passed to the `S3FileSystem` constructor is **appended** to the dvc-s3 suffix rather than replacing it, so the wire UA always carries the dvc-s3 identifier: with no override it is `dvc-s3/<version>`, and with `user_agent_extra="downstream/1.2.3"` it becomes `dvc-s3/<version> downstream/1.2.3`. The value is stripped of surrounding whitespace and rejected (`ConfigError`) if it contains control characters, to avoid malformed or injected `User-Agent` headers.

Note: this wires `user_agent_extra` at the `S3FileSystem` constructor / programmatic level. Reaching it through `dvc remote modify <name> user_agent_extra ...` additionally requires adding the key to DVC's S3 remote schema in `iterative/dvc`, which is a separate follow-up.

Tests in `dvc_s3/tests/test_s3.py` cover the default, the appended user value, whitespace stripping, control-character rejection, and the real on-the-wire `User-Agent` (via moto).
