### PR TITLE
feat: add storage_class, requester_pays, object_tags, and extra_s3_args config options

### DIFF
--- a/dvc_s3/__init__.py
+++ b/dvc_s3/__init__.py
@@ -203,6 +203,25 @@ class S3FileSystem(ObjectFileSystem):
                     )
                 additional[grant_key] = config[grant_option]
 
+        additional["StorageClass"] = config.get("storage_class")
+        additional["Tagging"] = config.get("object_tags")
+
+        if config.get("requester_pays"):
+            additional["RequestPayer"] = "requester"
+
+        if config.get("extra_s3_args"):
+            import json
+
+            try:
+                extra = json.loads(config["extra_s3_args"])
+            except json.JSONDecodeError as exc:
+                raise ConfigError(
+                    f"`extra_s3_args` is not valid JSON: {exc}"
+                ) from exc
+            if not isinstance(extra, dict):
+                raise ConfigError("`extra_s3_args` must be a JSON object")
+            additional.update(extra)
+
         # config kwargs
         session_config = login_info["config_kwargs"]
         session_config["s3"] = self._load_aws_config_file(login_info["profile"])

--- a/dvc_s3/__init__.py
+++ b/dvc_s3/__init__.py
@@ -142,11 +142,64 @@ class S3FileSystem(ObjectFileSystem):
         s3_config = profile_config.get("s3", {})
         return self._split_s3_config(s3_config)
 
-    def _prepare_credentials(self, **config):
+    def _prepare_sse_kwargs(self, config: dict) -> dict:
         import base64
 
-        from flatten_dict import flatten, unflatten
         from s3fs.utils import SSEParams
+
+        sse_customer_key = None
+        if config.get("sse_customer_key"):
+            if config.get("sse_kms_key_id"):
+                raise ConfigError(
+                    "`sse_kms_key_id` and `sse_customer_key` AWS S3 config "
+                    "options are mutually exclusive"
+                )
+            sse_customer_key = base64.b64decode(config.get("sse_customer_key"))
+        sse_customer_algorithm = config.get("sse_customer_algorithm")
+        if not sse_customer_algorithm and sse_customer_key:
+            sse_customer_algorithm = "AES256"
+        return SSEParams(
+            server_side_encryption=config.get("sse"),
+            sse_customer_algorithm=sse_customer_algorithm,
+            sse_customer_key=sse_customer_key,
+            sse_kms_key_id=config.get("sse_kms_key_id"),
+        ).to_kwargs()
+
+    def _prepare_s3_additional_kwargs(self, config: dict) -> dict:
+        import json
+
+        additional: dict = {}
+        additional.update(self._prepare_sse_kwargs(config))
+
+        additional["ACL"] = config.get("acl")
+        for grant_option, grant_key in self._GRANTS.items():
+            if config.get(grant_option):
+                if additional["ACL"]:
+                    raise ConfigError(
+                        "`acl` and `grant_*` AWS S3 config options "
+                        "are mutually exclusive"
+                    )
+                additional[grant_key] = config[grant_option]
+
+        additional["StorageClass"] = config.get("storage_class")
+        additional["Tagging"] = config.get("object_tags")
+
+        if config.get("requester_pays"):
+            additional["RequestPayer"] = "requester"
+
+        if config.get("extra_s3_args"):
+            try:
+                extra = json.loads(config["extra_s3_args"])
+            except json.JSONDecodeError as exc:
+                raise ConfigError(f"`extra_s3_args` is not valid JSON: {exc}") from exc
+            if not isinstance(extra, dict):
+                raise ConfigError("`extra_s3_args` must be a JSON object")
+            additional.update(extra)
+
+        return additional
+
+    def _prepare_credentials(self, **config):
+        from flatten_dict import flatten, unflatten
 
         login_info = defaultdict(dict)
 
@@ -173,54 +226,9 @@ class S3FileSystem(ObjectFileSystem):
         config_kwargs["read_timeout"] = config.get("read_timeout")
         config_kwargs["connect_timeout"] = config.get("connect_timeout")
 
-        # encryptions
-        additional = login_info["s3_additional_kwargs"]
-        sse_customer_key = None
-        if config.get("sse_customer_key"):
-            if config.get("sse_kms_key_id"):
-                raise ConfigError(
-                    "`sse_kms_key_id` and `sse_customer_key` AWS S3 config "
-                    "options are mutually exclusive"
-                )
-            sse_customer_key = base64.b64decode(config.get("sse_customer_key"))
-        sse_customer_algorithm = config.get("sse_customer_algorithm")
-        if not sse_customer_algorithm and sse_customer_key:
-            sse_customer_algorithm = "AES256"
-        sse_params = SSEParams(
-            server_side_encryption=config.get("sse"),
-            sse_customer_algorithm=sse_customer_algorithm,
-            sse_customer_key=sse_customer_key,
-            sse_kms_key_id=config.get("sse_kms_key_id"),
+        login_info["s3_additional_kwargs"].update(
+            self._prepare_s3_additional_kwargs(config)
         )
-        additional.update(sse_params.to_kwargs())
-        additional["ACL"] = config.get("acl")
-        for grant_option, grant_key in self._GRANTS.items():
-            if config.get(grant_option):
-                if additional["ACL"]:
-                    raise ConfigError(
-                        "`acl` and `grant_*` AWS S3 config options "
-                        "are mutually exclusive"
-                    )
-                additional[grant_key] = config[grant_option]
-
-        additional["StorageClass"] = config.get("storage_class")
-        additional["Tagging"] = config.get("object_tags")
-
-        if config.get("requester_pays"):
-            additional["RequestPayer"] = "requester"
-
-        if config.get("extra_s3_args"):
-            import json
-
-            try:
-                extra = json.loads(config["extra_s3_args"])
-            except json.JSONDecodeError as exc:
-                raise ConfigError(
-                    f"`extra_s3_args` is not valid JSON: {exc}"
-                ) from exc
-            if not isinstance(extra, dict):
-                raise ConfigError("`extra_s3_args` must be a JSON object")
-            additional.update(extra)
 
         # config kwargs
         session_config = login_info["config_kwargs"]

--- a/dvc_s3/tests/test_s3.py
+++ b/dvc_s3/tests/test_s3.py
@@ -136,3 +136,67 @@ def test_key_id_and_secret():
     assert fs.fs_args["key"] == key_id
     assert fs.fs_args["secret"] == key_secret
     assert fs.fs_args["token"] == session_token
+
+
+def test_storage_class():
+    fs = S3FileSystem(url=url, storage_class="REDUCED_REDUNDANCY")
+    assert fs.fs_args["s3_additional_kwargs"]["StorageClass"] == "REDUCED_REDUNDANCY"
+
+
+def test_storage_class_not_set():
+    fs = S3FileSystem(url=url)
+    assert "StorageClass" not in fs.fs_args.get("s3_additional_kwargs", {})
+
+
+def test_requester_pays():
+    fs = S3FileSystem(url=url, requester_pays=True)
+    assert fs.fs_args["s3_additional_kwargs"]["RequestPayer"] == "requester"
+
+
+def test_requester_pays_not_set():
+    fs = S3FileSystem(url=url)
+    assert "RequestPayer" not in fs.fs_args.get("s3_additional_kwargs", {})
+
+
+def test_object_tags():
+    fs = S3FileSystem(url=url, object_tags="env=prod&team=ml")
+    assert fs.fs_args["s3_additional_kwargs"]["Tagging"] == "env=prod&team=ml"
+
+
+def test_object_tags_not_set():
+    fs = S3FileSystem(url=url)
+    assert "Tagging" not in fs.fs_args.get("s3_additional_kwargs", {})
+
+
+def test_extra_s3_args():
+    fs = S3FileSystem(url=url, extra_s3_args='{"StorageClass": "WARM"}')
+    assert fs.fs_args["s3_additional_kwargs"]["StorageClass"] == "WARM"
+
+
+def test_extra_s3_args_multiple_keys():
+    fs = S3FileSystem(
+        url=url,
+        extra_s3_args='{"StorageClass": "COLD", "RequestPayer": "requester"}',
+    )
+    extra = fs.fs_args["s3_additional_kwargs"]
+    assert extra["StorageClass"] == "COLD"
+    assert extra["RequestPayer"] == "requester"
+
+
+def test_extra_s3_args_overrides_named_param():
+    fs = S3FileSystem(
+        url=url,
+        storage_class="STANDARD",
+        extra_s3_args='{"StorageClass": "REDUCED_REDUNDANCY"}',
+    )
+    assert fs.fs_args["s3_additional_kwargs"]["StorageClass"] == "REDUCED_REDUNDANCY"
+
+
+def test_extra_s3_args_invalid_json():
+    with pytest.raises(ConfigError):
+        S3FileSystem(url=url, extra_s3_args="not-json").fs_args  # noqa: B018
+
+
+def test_extra_s3_args_not_a_dict():
+    with pytest.raises(ConfigError):
+        S3FileSystem(url=url, extra_s3_args='"just-a-string"').fs_args  # noqa: B018


### PR DESCRIPTION
## Problem

Users running DVC against S3-compatible providers (MinIO, Scaleway, Ceph, DigitalOcean Spaces, etc.) often need to control per-object S3 parameters — most commonly `StorageClass` — that the provider requires or that differs from the AWS default. There was no way to set these through DVC config; values were silently ignored.

## Solution

Four new `dvc remote modify` config parameters that map into `s3_additional_kwargs`, which `s3fs` forwards to every boto3 write call:

| Config key | boto3 key | Notes |
|---|---|---|
| `storage_class` | `StorageClass` | e.g. `STANDARD`, `REDUCED_REDUNDANCY`, or provider-specific class |
| `requester_pays` | `RequestPayer` | Boolean; sets value to `"requester"` for requester-pays buckets |
| `object_tags` | `Tagging` | URL-encoded key=value pairs, e.g. `env=prod&team=ml` |
| `extra_s3_args` | merged into kwargs | Generic JSON escape hatch for any other boto3 S3 write param; overrides named params on key collision |

`None`-valued keys are filtered out by the existing `flatten/unflatten` logic so unset params do not pollute the dict.

## Usage

```bash
dvc remote modify myremote storage_class REDUCED_REDUNDANCY
dvc remote modify myremote requester_pays true
dvc remote modify myremote object_tags "env=prod&team=ml"
# or for anything not natively supported:
dvc remote modify myremote extra_s3_args '{"StorageClass": "WARM"}'
```

## Tests

11 new unit tests — 20/20 passing. Covers each new param, the not-set case, JSON error handling, and `extra_s3_args` overriding a named param.

Docs PR: iterative/dvc.org (link to follow)